### PR TITLE
Update Dockerfile.tf2

### DIFF
--- a/Dockerfile.tf2
+++ b/Dockerfile.tf2
@@ -7,7 +7,7 @@ WORKDIR /usr/mead
 
 RUN cd xpctl/ && pip install -e .
 RUN cd mead-baseline/layers && pip install -e .
-RUN cd mead-baseline && pip install -e .[test,yaml]
+RUN cd mead-baseline && pip install -e .[tf2,test,yaml]
 
 # Set env variables
 # Set baseline logging vars


### PR DESCRIPTION
`tensorflow_addons`isn't installed in this container but baseline needs it when running tf2. This update uses the extra requires to install that.

Will merging this trigger a new release on dockerhub?