### PR TITLE
chore: add tensorboard to the pytorch container for metrics

### DIFF
--- a/Dockerfile.pytorch
+++ b/Dockerfile.pytorch
@@ -24,6 +24,7 @@ COPY . /usr/mead
 RUN python3.6 -m pip install torch==1.5.0+cu101 -f https://download.pytorch.org/whl/torch_stable.html && \
     python3.6 -m pip install Cython && \
     python3.6 -m pip install fastBPE && \
+    python3.6 -m pip install tensorboard && \
     python3.6 -m pip install mead-xpctl
 
 ENTRYPOINT ["mead-train", "--config", "config/conll.json"]


### PR DESCRIPTION
This change is needed to use the tensorboard logging hook from inside the pytorch container